### PR TITLE
Bugfix for OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(sp VERSION 2.0.2)
 set(${PROJECT_NAME}_VERSION ${PROJECT_VERSION} CACHE INTERNAL "${PROJECT_NAME} version number")
 enable_language (Fortran)
 
+option(OPENMP "use OpenMP threading" OFF)
+
 if (NOT CMAKE_BUILD_TYPE)
   set (CMAKE_BUILD_TYPE RELEASE CACHE STRING
     "Choose the type of build, options are: PRODUCTION Debug Release."
@@ -22,6 +24,11 @@ STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "RELEASE" BUILD_RELEASE)
 STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "PRODUCTION" BUILD_PRODUCTION)
 STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "DEBUG" BUILD_DEBUG)
 
+if(OPENMP)
+  find_package(OpenMP)
+  add_definitions(-DOPENMP)
+endif()
+
 if(APPLE)
   set(platform_definition "APPLE")
 else()
@@ -30,13 +37,13 @@ endif()
 
 if( (BUILD_RELEASE) OR (BUILD_PRODUCTION) )
   if(IntelComp)
-    set(shared_fortran_flags "-O3" "-auto" "-qopenmp" "-convert" "big_endian" "-assume" "byterecl"
-      "-fp-model" "strict" "-fpp")
+    set(shared_fortran_flags "-O3" "-auto" "-convert" "big_endian" "-assume" "byterecl"
+      "-fp-model" "strict" "-fpp" "${OpenMP_Fortran_FLAGS}")
     set(fortran_d_flags "-i4" "-r8")
     set(fortran_8_flags "-i8" "-r8")
     set(fortran_4_flags "-i4" "-real-size" "32")
   elseif(GNUComp)
-    set(shared_fortran_flags "-O3" "-fconvert=big-endian")
+    set(shared_fortran_flags "-O3" "-fconvert=big-endian" "-cpp" "${OpenMP_Fortran_FLAGS}")
     set(fortran_d_flags "-fdefault-real-8")
     set(fortran_8_flags "-fdefault-integer-8" "-fdefault-real-8")
     set(fortran_4_flags)

--- a/src/ncpus.F
+++ b/src/ncpus.F
@@ -29,6 +29,7 @@ C$$$
 C - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
       INTEGER NTHREADS, TID, OMP_GET_NUM_THREADS,OMP_GET_THREAD_NUM
 C     Obtain thread number
+#ifdef OPENMP
 #if defined LINUX || defined APPLE
 !$OMP PARALLEL PRIVATE(TID)
       TID = OMP_GET_THREAD_NUM()
@@ -41,6 +42,9 @@ C     Obtain thread number
 #else
       NCPUS=NUM_PARTHDS()
 #endif
-
+#else
+      TID = 0
+      NCPUS = 1
+#endif
       RETURN
       END


### PR DESCRIPTION
- update OpenMP logic: by default, OpenMP is off
- add guard around OpenMP calls (`OMP_GET_THREAD_NUM` etc) to `src/ncpus.F`