### PR TITLE
CI cleanup;  all CI runs must complete successfully before merge to develop

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -1,5 +1,15 @@
 name: Intel
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
+  pull_request:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
 
 # Use custom shell with -l so .bash_profile is sourced which loads intel/oneapi/setvars.sh
 # without having to do it in manually every step
@@ -47,4 +57,4 @@ jobs:
     - name: test-sp
       run: |
         cd sp/build
-        ctest --output-on-failure
+        ctest --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -23,7 +23,6 @@ jobs:
     env:
       CC: icc
       FC: ifort
-      CXX: icpc
     strategy:
       matrix:
         openmp: [ON, OFF]
@@ -51,8 +50,8 @@ jobs:
       run: |
         cd sp
         mkdir build && cd build
-        cmake .. -DOPENMP=${{ matrix.openmp }}
-        make -j2
+        cmake -DOPENMP=${{ matrix.openmp }} ..
+        make -j2 VERBOSE=1
 
     - name: test-sp
       run: |

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -18,7 +18,7 @@ defaults:
     shell: bash -leo pipefail {0}
 
 jobs:
-  intel-build:
+  Intel:
     runs-on: ubuntu-latest
     env:
       CC: icc

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -1,0 +1,41 @@
+name: Linux
+on:
+  push:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
+  pull_request:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
+
+jobs:
+  Linux:
+    runs-on: ubuntu-latest
+    env:
+      FC: gfortran-9
+      CC: gcc-9
+
+    steps:
+    
+    - name: checkout-sp
+      uses: actions/checkout@v2
+      with: 
+        path: sp
+
+    - name: build-sp
+      run: |
+        cd sp
+        mkdir build 
+        cd build
+        cmake .. -DCMAKE_PREFIX_PATH="~/" 
+        make -j2
+
+    - name: test-sp
+      run: |
+        cd sp/build
+        ctest --verbose --output-on-failure --rerun-failed
+
+

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -15,8 +15,8 @@ jobs:
   Linux:
     runs-on: ubuntu-latest
     env:
-      FC: gfortran-9
-      CC: gcc-9
+      FC: gfortran-10
+      CC: gcc-10
 
     steps:
     

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -31,7 +31,7 @@ jobs:
         mkdir build 
         cd build
         cmake .. -DCMAKE_PREFIX_PATH="~/" 
-        make -j2
+        make -j2 VERBOSE=1
 
     - name: test-sp
       run: |

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -17,6 +17,9 @@ jobs:
     env:
       FC: gfortran-10
       CC: gcc-10
+    strategy:
+      matrix:
+        openmp: [ON, OFF]
 
     steps:
     
@@ -30,7 +33,7 @@ jobs:
         cd sp
         mkdir build 
         cd build
-        cmake .. -DCMAKE_PREFIX_PATH="~/" 
+        cmake .. -DOPENMP=${{ matrix.openmp }}
         make -j2 VERBOSE=1
 
     - name: test-sp

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -15,10 +15,9 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: ${{ matrix.compiler }}
+      FC: gfortran-10
     strategy:
       matrix:
-        compiler: [gfortran-10, gfortran-11]
         openmp: [ON, OFF]
 
     steps:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -33,7 +33,7 @@ jobs:
         mkdir build 
         cd build
         cmake .. -DOPENMP=${{ matrix.openmp }}
-        make -j2
+        make -j2 VERBOSE=1
 
     - name: test-sp
       run: |

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -15,7 +15,7 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran-10
+      FC: gfortran-11
     strategy:
       matrix:
         openmp: [ON, OFF]

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -1,15 +1,24 @@
-name: macOS-Linux-GCC
-on: [push, pull_request]
+name: MacOS
+on:
+  push:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
+  pull_request:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
 
 jobs:
-  mac-linux-build:
-    runs-on: ${{ matrix.os }}
+  MacOS:
+    runs-on: macos-latest
     env:
       FC: ${{ matrix.compiler }}
     strategy:
       matrix:
-        compiler: [gfortran-9, gfortran-10]
-        os: [ubuntu-latest, macos-latest]
+        compiler: [gfortran-10, gfortran-11]
         openmp: [ON, OFF]
 
     steps:
@@ -30,5 +39,5 @@ jobs:
     - name: test-sp
       run: |
         cd sp/build
-        ctest --output-on-failure
+        ctest --verbose --output-on-failure --rerun-failed
 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -35,7 +35,7 @@ jobs:
         cd sp
         mkdir build 
         cd build
-        cmake .. -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0"
+        cmake .. -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0 -fsanitize=address"
         make -j2
 
     - name: test-sp

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -35,7 +35,7 @@ jobs:
         cd sp
         mkdir build 
         cd build
-        cmake .. -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0 -fsanitize=address"
+        cmake -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0 -fsanitize=address" -DCMAKE_BUILD_TYPE=Debug ..
         make -j2
 
     - name: test-sp

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -38,11 +38,6 @@ jobs:
         cmake .. -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0"
         make -j2
 
-    - name: build-docs
-      run: |
-        cd sp/build
-        make doc
-
     - name: test-sp
       run: |
         cd sp/build
@@ -56,5 +51,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: sp-test-coverage
-        path: sp/build/*.html
+        path: |
+              sp/build/*.html 
+              sp/build/*.css
 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -35,7 +35,7 @@ jobs:
         cd sp
         mkdir build 
         cd build
-        cmake -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0 -fsanitize=address" -DCMAKE_BUILD_TYPE=Debug ..
+        cmake -DOPENMP=ON -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0 -fsanitize=address" -DCMAKE_BUILD_TYPE=Debug ..
         make -j2 VERBOSE=1
 
     - name: test-sp

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -36,7 +36,7 @@ jobs:
         mkdir build 
         cd build
         cmake -DCMAKE_PREFIX_PATH="~/" -DENABLE_DOCS=ON -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -O0 -fsanitize=address" -DCMAKE_BUILD_TYPE=Debug ..
-        make -j2
+        make -j2 VERBOSE=1
 
     - name: test-sp
       run: |

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -1,8 +1,18 @@
-name: gcc-9_debug_docs-test_coverage
-on: [push, pull_request]
+name: developer
+on:
+  push:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
+  pull_request:
+    branches:
+    - develop
+    paths-ignore:
+    - README.md
 
 jobs:
-  debug-docs-test_coverage:
+  developer:
     runs-on: ubuntu-latest
     env:
       FC: gfortran-9
@@ -36,7 +46,7 @@ jobs:
     - name: test-sp
       run: |
         cd sp/build
-        ctest --output-on-failure
+        ctest --verbose --output-on-failure --rerun-failed
 
     - name: generate-test-coverage
       run: |


### PR DESCRIPTION
Fixes #69 

Last changes to CI.

Also now all CI runs must complete successfully before merge to develop.