### PR TITLE
Update user guide with reference to v2.3.3 docs

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,5 +1,9 @@
 @mainpage
 
+## Documentation for Previous Versions of NCEPLIBS-sp
+
+* [NCEPLIBS-sp Version 2.3.3](v2.3.3/index.html)
+
 ## Introduction
 
 The spectral transform library splib, developed in the 1990s,


### PR DESCRIPTION
Adding reference/links to v2.3.3 docs (see https://github.com/NOAA-EMC/NCEPLIBS-sp/pull/96).