### PR TITLE
Allow downstream packages to request shared or static library of package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 option(BUILD_STATIC_LIBS "Build static libraries" ON)
 option(BUILD_4 "Build the 4-byte real version of the library, libsp_4.a" ON)
 option(BUILD_D "Build the 8-byte real version of the library, libsp_d.a" ON)
+option(BUILD_TESTING "Build tests of the library" ON)
 
 # Figure whether user wants a _4, a _d, or both libraries.
 if(BUILD_4 AND BUILD_D)
@@ -75,16 +76,16 @@ endif()
 add_subdirectory(src)
 
 # Build and run tests.
-include(CTest)
-if (BUILD_TESTING)
-    add_subdirectory(tests)
+if(BUILD_TESTING)
+  include(CTest)
+  add_subdirectory(tests)
 endif()
 
 # Does the user want to generate documentation?
-IF(ENABLE_DOCS)
-  FIND_PACKAGE(Doxygen REQUIRED)
-ENDIF()
-ADD_SUBDIRECTORY(docs)  
+if(ENABLE_DOCS)
+  find_package(Doxygen REQUIRED)
+  add_subdirectory(docs)
+endif()
 
 
 

--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -1,17 +1,42 @@
 @PACKAGE_INIT@
 
 #  * @PROJECT_NAME@::@PROJECT_NAME@_4 - real32 library target
-#  * @PROJECT_NAME@::@PROJECT_NAME@_8 - real64 library target
 #  * @PROJECT_NAME@::@PROJECT_NAME@_d - mixed library target
-include(CMakeFindDependencyMacro)
 
 # Include targets file.  This will create IMPORTED target @PROJECT_NAME@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
-
-get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_4 IMPORTED_CONFIGURATIONS)
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-config-version.cmake")
+include(CMakeFindDependencyMacro)
 
 if(@OPENMP@)
-  find_dependency(OpenMP COMPONENTS Fortran)
+  find_dependency(OpenMP COMPONENT Fortran)
+endif()
+
+# Initialize the static/shared builds of this library
+set(@PROJECT_NAME@_HAS_STATIC_LIBS OFF)
+if(@BUILD_STATIC_LIBS@)
+  set(@PROJECT_NAME@_HAS_STATIC_LIBS ON)
+endif()
+
+set(@PROJECT_NAME@_HAS_SHARED_LIBS OFF)
+if(@BUILD_SHARED_LIBS@)
+  set(@PROJECT_NAME@_HAS_SHARED_LIBS ON)
+endif()
+
+# By default, prefer to use STATIC libs
+# If the user wishes to use SHARED libs, they can do so by either:
+# 1. set(sp_USE_SHARED_LIBS ON) in their project, or
+# 2. -Dsp_USE_SHARED_LIBS=ON during their project configuration
+if(@PROJECT_NAME@_USE_SHARED_LIBS)
+  # First check if @PROJECT_NAME@ was built with SHARED libs, if not, error out.
+  if(NOT @PROJECT_NAME@_HAS_SHARED_LIBS)
+    message(FATAL "@PROJECT_NAME@ was not built as a shared library, try static instead")
+  endif()
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_4 ALIAS @PROJECT_NAME@::@PROJECT_NAME@_4_shared)
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_d ALIAS @PROJECT_NAME@::@PROJECT_NAME@_d_shared)
+else()
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_4 ALIAS @PROJECT_NAME@::@PROJECT_NAME@_4_static)
+  add_library(@PROJECT_NAME@::@PROJECT_NAME@_d ALIAS @PROJECT_NAME@::@PROJECT_NAME@_d_static)
 endif()
 
 check_required_components("@PROJECT_NAME@")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,28 +24,23 @@ foreach(kind ${kinds})
   if(BUILD_SHARED_LIBS)
     set_property(TARGET ${lib_name}_objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
   endif()
-  add_library(${PROJECT_NAME}::${lib_name} ALIAS ${lib_name}_objlib)
+  # Set the flags for ${kind}
+  set_target_properties(${lib_name}_objlib PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
 
   if(BUILD_STATIC_LIBS)
     # Create static object library from object library.
     add_library(${lib_name}_static STATIC $<TARGET_OBJECTS:${lib_name}_objlib>)
-    set_target_properties(${lib_name}_static PROPERTIES OUTPUT_NAME ${lib_name})
-    set_target_properties(${lib_name}_static PROPERTIES EXPORT_NAME ${lib_name})
-    set_target_properties(${lib_name}_static PROPERTIES EXPORT_NAME ${lib_name}_static)
+    add_library(${PROJECT_NAME}::${lib_name}_static ALIAS ${lib_name}_static)
     list(APPEND LIB_TARGETS ${lib_name}_static)
   endif()
 
   if(BUILD_SHARED_LIBS)
     # Create shared object library from object library.
     add_library(${lib_name}_shared SHARED $<TARGET_OBJECTS:${lib_name}_objlib>)
-    set_target_properties(${lib_name}_shared PROPERTIES OUTPUT_NAME ${lib_name})
-    set_target_properties(${lib_name}_shared PROPERTIES EXPORT_NAME ${lib_name})
+    add_library(${PROJECT_NAME}::${lib_name}_shared ALIAS ${lib_name}_shared)
     set_target_properties(${lib_name}_shared PROPERTIES SOVERSION 0)
     list(APPEND LIB_TARGETS ${lib_name}_shared)
   endif()
-
-  # Set the flags for _4 or _d.
-  set(BUILD_FLAGS "${fortran_${kind}_flags}")
 
   # Deal with OpenMP.
   if(OpenMP_Fortran_FOUND)
@@ -56,8 +51,6 @@ foreach(kind ${kinds})
       target_link_libraries(${lib_name}_static PRIVATE OpenMP::OpenMP_Fortran)
     endif()
   endif()
-  
-  set_target_properties(${lib_name}_objlib PROPERTIES COMPILE_FLAGS "${BUILD_FLAGS}")
 
 endforeach()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,10 +10,10 @@ function(create_test name kind)
   if(OpenMP_Fortran_FOUND)
     target_link_libraries(${name}_${kind} PRIVATE OpenMP::OpenMP_Fortran)
   endif()
-  target_link_libraries(${name}_${kind} PRIVATE sp::sp_${kind})
+  target_link_libraries(${name}_${kind} PRIVATE sp::sp_${kind}_static)  # use static library for tests
   set_target_properties(${name}_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
   add_test(NAME ${name}_${kind} COMMAND ${name}_${kind})
-  target_compile_definitions(${name}_${kind} PUBLIC -DKIND_${kind})  
+  target_compile_definitions(${name}_${kind} PUBLIC -DKIND_${kind})
 endfunction()
 
 # At the moment, only _d is tested.


### PR DESCRIPTION
This PR:
- allows downstream packages to find and use static (default) or dynamic version of the `sp` library.

If both types are built, static is preferred.

To request a shared type, the user can do either of the following in their project.
```
set(sp_USE_SHARED_LIBS ON)
```
or during configuration pass this option at the command line:
```
-Dsp_USE_SHARED_LIBS=ON
```

[This](https://github.com/NOAA-EMC/NCEPLIBS-ip/tree/feature/staticshared)  branch in `NCEPlibs-ip` can be used to demonstrate the above.