### PR TITLE
install shared library on MacOS build to make sure it worked

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -34,8 +34,11 @@ jobs:
         cd sp
         mkdir build 
         cd build
-        cmake .. -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }}
+        cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} -DCMAKE_INSTALL_PREFIX=./install ..
         make -j2 VERBOSE=1
+        make install
+        ls -l ~/install
+        ls -l ~/install/lib
 
     - name: test-sp
       run: |

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -34,7 +34,7 @@ jobs:
         cd sp
         mkdir build 
         cd build
-        cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} -DCMAKE_INSTALL_PREFIX=./install ..
+        cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} -DCMAKE_INSTALL_PREFIX=~/install ..
         make -j2 VERBOSE=1
         make install
         ls -l ~/install


### PR DESCRIPTION
Part of #69.

Doublecheck MacOS shared library builds by doing an install that can be checked visually in the CI output.