### PR TITLE
Add BUILD_DEPRECATED option to disable unused functions by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
 option(BUILD_4 "Build the 4-byte real version of the library, libsp_4.a" ON)
 option(BUILD_D "Build the 8-byte real version of the library, libsp_d.a" ON)
 option(BUILD_8 "Build the 8-byte integer version of the library, libsp_8.a" OFF)
+option(BUILD_DEPRECATED "Build deprecated functions" OFF)
 
 # Figure whether user wants a _4, a _d, or both libraries.
 if(BUILD_4)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,15 +3,17 @@
 # Mark Potts, Kyle Gerheiser, Ed Hartnett
 
 # These are the source files.
-set(fortran_src fftpack.F lapack_gen.F ncpus.F spanaly.f spdz2uv.f
-speps.f spfft1.f spffte.f spfft.f spfftpt.f spgradq.f spgradx.f
-spgrady.f splaplac.f splat.F splegend.f sppad.f spsynth.f sptezd.f
-sptez.f sptezmd.f sptezm.f sptezmv.f sptezv.f sptgpmd.f sptgpm.f
-sptgpmv.f sptgpsd.f sptgps.f sptgpsv.f sptgptd.f sptgpt.f sptgptsd.f
-sptgptvd.f sptgptv.f sptrand.f sptran.f sptranf0.f sptranf1.f
-sptranf.f sptranfv.f sptranv.f sptrund.f sptrun.f sptrung.f sptrungv.f
-sptrunl.f sptrunm.f sptrunmv.f sptruns.f sptrunsv.f sptrunv.f
-spuv2dz.f spvar.f spwget.f)
+set(fortran_src fftpack.F lapack_gen.F ncpus.F spanaly.f spdz2uv.f speps.f
+spfft1.f spffte.f spfftpt.f splaplac.f splat.F splegend.f sppad.f spsynth.f
+sptezd.f sptez.f sptezmd.f sptezm.f sptezmv.f sptezv.f sptgpm.f sptgpmv.f
+sptgps.f sptgpsv.f sptgpt.f sptgptv.f sptrand.f sptran.f sptranf0.f sptranf1.f
+sptranf.f sptranfv.f sptranv.f sptrun.f sptrung.f sptrungv.f sptrunm.f
+sptrunmv.f sptruns.f sptrunsv.f sptrunv.f spuv2dz.f spwget.f)
+
+if(BUILD_DEPRECATED)
+  set(fortran_src ${fortran_src} spfft.f spgradq.f spgradx.f spgrady.f sptgpmd.f
+  sptgpsd.f sptgptd.f sptgptsd.f sptgptvd.f sptrund.f sptrunl.f spvar.f)
+endif()
 
 # We can build two versions of the library, _4 for standard, and _d for
 # 8-byte float.


### PR DESCRIPTION
This PR adds a build option, BUILD_DEPRECATED, that is off by default and disables various code not used by NCEP models.

Fixes #109