### PR TITLE
Fix _8 option in Linux.yml

### DIFF
--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         openmp: [ON, OFF]
         sharedlibs: [ON, OFF]
-        options: [-DBUILD_D=OFF, -DBUILD_4=OFF, BUILD_8=ON]
+        options: [-DBUILD_D=OFF, -DBUILD_4=OFF, -DBUILD_8=ON]
 
     steps:
     


### PR DESCRIPTION
This PR fixes the BUILD_8 setting in the Linux.yml CI.

Fixes #111