### PR TITLE
Add Intel LLVM support

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -1,6 +1,6 @@
 # This is a CI workflow for the NCEPLIBS-sp project.
 #
-# This workflow builds with the Intel compiler.
+# This workflow builds with the Intel Classic and OneAPI compilers.
 #
 # Ed Hartnett, 1/8/23
 name: Intel

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -21,13 +21,11 @@ defaults:
 jobs:
   Intel:
     runs-on: ubuntu-latest
-    env:
-      CC: icc
-      FC: ifort
     strategy:
       matrix:
         openmp: [ON, OFF]
         sharedlibs: [ON, OFF]
+        compilers: ["CC=icc FC=ifort", "CC=icx FC=ifx"]
 
     steps:
 
@@ -52,7 +50,7 @@ jobs:
       run: |
         cd sp
         mkdir build && cd build
-        cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} ..
+        ${{ matrix.compilers }} cmake -DOPENMP=${{ matrix.openmp }} -DBUILD_SHARED_LIBS=${{ matrix.sharedlibs }} ..
         make -j2 VERBOSE=1
 
     - name: test-sp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(OpenMP_FOUND)
 endif()
 
 # Set compiler flags.
-if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_Fortran_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_Fortran_FLAGS
     "-g -traceback -auto -convert big_endian -assume byterecl -fp-model strict -fpp ${CMAKE_Fortran_FLAGS}")
   set(CMAKE_Fortran_FLAGS_RELEASE "-O3")

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -8,7 +8,8 @@
 
 The spectral transform library splib, developed in the 1990s,
 contains FORTRAN subprograms to be used for a variety of spectral
-transform functions.
+transform functions. Supported compilers include GCC, Intel Classic,
+Intel OneAPI, and the NVIDIA HPC SDK.
 
 The library has been optimized for the CRAY machines, taking full
 advantage of both the vector and parallel capabilities. The library is


### PR DESCRIPTION
Adding Intel LLVM support.

Tested on Hera with Intel OneAPI 2023.1.0. No compiler warnings, and no apparent issues with compiler flags.

Fixes https://github.com/NOAA-EMC/NCEPLIBS-sp/issues/113