### PR TITLE
Add Spack-based CI

### DIFF
--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -37,7 +37,7 @@ jobs:
         spack env create sp-env
         spack env activate sp-env
         cp $GITHUB_WORKSPACE/sp/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/sp/package.py
-        mv ~/sp $SPACK_ENV/sp
+        mv $GITHUB_WORKSPACE/sp $SPACK_ENV/sp
         spack develop --no-clone sp@develop
         spack add sp@develop%gcc@11 ${{ matrix.openmp }} ${{ matrix.sharedlibs }} ${{ matrix.pic }} ${{ matrix.precision }}
         spack external find cmake gmake

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -61,6 +61,7 @@ jobs:
 
     - name: recipe-check
       run: |
+        echo "If this jobs fails, look at the most recently output CMake option below and make sure that option appears in spack/package.py"
         for opt in $(grep -ioP '^option\(\K(?!(ENABLE_DOCS))[^ ]+' $GITHUB_WORKSPACE/sp/CMakeLists.txt) ; do
           echo "Checking for presence of '$opt' CMake option in package.py"
           grep -cP "define.+\b${opt}\b" $GITHUB_WORKSPACE/sp/spack/package.py

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
     
     - name: checkout-sp
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with: 
-        path: ~/sp
+        path: sp
 
     - name: spack-build-and-test
       run: |
@@ -36,9 +36,7 @@ jobs:
         . spack/share/spack/setup-env.sh
         spack env create sp-env
         spack env activate sp-env
-        ls ~/sp
-        ls ~/sp/spack
-        cp ~/sp/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/sp/package.py
+        cp $GITHUB_WORKSPACE/sp/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/sp/package.py
         mv ~/sp $SPACK_ENV/sp
         spack develop --no-clone sp@develop
         spack add sp@develop%gcc@11 ${{ matrix.openmp }} ${{ matrix.sharedlibs }} ${{ matrix.pic }} ${{ matrix.precision }}

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         openmp: ["+openmp", "~openmp"]
-        shared: ["+shared", "~shared"]
-        pic: ["+pic", "~pic"
+        sharedlibs: ["+shared", "~shared"]
+        pic: ["+pic", "~pic"]
         precision: ["precision=d", "precision=4", "precision=8"]
 
     steps:
@@ -39,7 +39,7 @@ jobs:
         cp ~/sp/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/sp/package.py
         mv ~/sp $SPACK_ENV/sp
         spack develop --no-clone sp@develop
-        spack add sp@develop%gcc@11 ${{ matrix.openmp }} ${{ matrix.shared }} ${{ matrix.pic }} ${{ matrix.precision }}
+        spack add sp@develop%gcc@11 ${{ matrix.openmp }} ${{ matrix.sharedlibs }} ${{ matrix.pic }} ${{ matrix.precision }}
         spack external find cmake gmake
         spack concretize
         spack install --verbose --test root

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -1,7 +1,9 @@
 # This is a CI workflow for the NCEPLIBS-sp project.
 #
-# This workflow builds sp with Spack, including installing with the "--test root"
-# option to run the CTest suite.
+# This workflow builds sp with Spack, including installing with the "--test
+# root" option to run the CTest suite. It also has a one-off job that validates
+# the recipe by ensuring that every CMake option that should be set in the
+# Spack recipe is so set.
 #
 # Alex Richert, Sep 2023
 name: Spack
@@ -14,8 +16,10 @@ on:
     - develop
 
 jobs:
+  # This job builds with Spack using every combination of variants and runs the CTest suite each time
   Linux:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         openmp: ["+openmp", "~openmp"]
@@ -43,3 +47,21 @@ jobs:
         spack external find cmake gmake
         spack concretize
         spack install --verbose --test root
+
+  # This job validates the Spack recipe by making sure each cmake build option is represented
+  recipe-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    
+    - name: checkout-sp
+      uses: actions/checkout@v4
+      with: 
+        path: sp
+
+    - name: recipe-check
+      run: |
+        for opt in $(grep -ioP '^option\(\K(?!(ENABLE_DOCS))[^ ]+' $GITHUB_WORKSPACE/sp/CMakeLists.txt) ; do
+          echo "Checking for presence of '$opt' CMake option in package.py"
+          grep -cP "define.+\b${opt}\b" $GITHUB_WORKSPACE/sp/spack/package.py
+        done

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     
     - name: checkout-sp
-      uses: actions/checkout@v3
+      uses: actions/checkout@v2
       with: 
         path: ~/sp
 
@@ -36,6 +36,8 @@ jobs:
         . spack/share/spack/setup-env.sh
         spack env create sp-env
         spack env activate sp-env
+        ls ~/sp
+        ls ~/sp/spack
         cp ~/sp/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/sp/package.py
         mv ~/sp $SPACK_ENV/sp
         spack develop --no-clone sp@develop

--- a/.github/workflows/spack.yml
+++ b/.github/workflows/spack.yml
@@ -1,0 +1,45 @@
+# This is a CI workflow for the NCEPLIBS-sp project.
+#
+# This workflow builds sp with Spack, including installing with the "--test root"
+# option to run the CTest suite.
+#
+# Alex Richert, Sep 2023
+name: Spack
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+  Linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        openmp: ["+openmp", "~openmp"]
+        shared: ["+shared", "~shared"]
+        pic: ["+pic", "~pic"
+        precision: ["precision=d", "precision=4", "precision=8"]
+
+    steps:
+    
+    - name: checkout-sp
+      uses: actions/checkout@v3
+      with: 
+        path: ~/sp
+
+    - name: spack-build-and-test
+      run: |
+        git clone -c feature.manyFiles=true https://github.com/spack/spack
+        . spack/share/spack/setup-env.sh
+        spack env create sp-env
+        spack env activate sp-env
+        cp ~/sp/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/sp/package.py
+        mv ~/sp $SPACK_ENV/sp
+        spack develop --no-clone sp@develop
+        spack add sp@develop%gcc@11 ${{ matrix.openmp }} ${{ matrix.shared }} ${{ matrix.pic }} ${{ matrix.precision }}
+        spack external find cmake gmake
+        spack concretize
+        spack install --verbose --test root

--- a/spack/README
+++ b/spack/README
@@ -1,0 +1,3 @@
+This directory contains an authoritative, up-to-date Spack recipe for NCEPLIBS-sp, which is found under Spack as "sp".
+
+Before each release of NCEPLIBS-sp, this file should be updated to accommodate changes in build options, etc., and .github/workflows/spack.yml should be updated to exercise all variants. Only the version entry should need to be updated after the release prior to incorporation into the Spack repository and the JCSDA Spack fork.

--- a/spack/package.py
+++ b/spack/package.py
@@ -57,4 +57,5 @@ class Sp(CMakePackage):
         args.append(self.define("BUILD_4", self.spec.satisfies("precision=4")))
         args.append(self.define("BUILD_D", self.spec.satisfies("precision=d")))
         args.append(self.define("BUILD_8", self.spec.satisfies("precision=8")))
+        args.append(self.define("BUILD_DEPRECATED", False))
         return args

--- a/spack/package.py
+++ b/spack/package.py
@@ -1,0 +1,46 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Sp(CMakePackage):
+    """The spectral transform library splib contains FORTRAN subprograms
+    to be used for a variety of spectral transform functions. This is
+    part of the NCEPLIBS project."""
+
+    homepage = "https://noaa-emc.github.io/NCEPLIBS-sp"
+    url = "https://github.com/NOAA-EMC/NCEPLIBS-sp/archive/refs/tags/v2.3.3.tar.gz"
+
+    maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
+
+    version("2.4.0", sha256="dbb4280e622d2683b68a28f8e3837744adf9bbbb1e7940856e8f4597f481c708")
+    version("2.3.3", sha256="c0d465209e599de3c0193e65671e290e9f422f659f1da928505489a3edeab99f")
+
+    variant("openmp", default=True, description="builds with OpenMP support")
+    variant("shared", default=False, description="Build shared library", when="@2.4:")
+    variant("pic", default=True, description="Build with position-independent-code")
+
+    def setup_run_environment(self, env):
+        suffixes = ["4", "d"]
+        if self.spec.satisfies("@:2.3"):
+            suffixes += ["8"]
+        for suffix in suffixes:
+            lib = find_libraries(
+                "libsp_" + suffix,
+                root=self.prefix,
+                shared=self.spec.satisfies("+shared"),
+                recursive=True,
+            )
+            env.set("SP_LIB" + suffix, lib[0])
+            env.set("SP_INC" + suffix, "include_" + suffix)
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("OPENMP", "openmp"),
+            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+        ]
+        return args

--- a/spack/package.py
+++ b/spack/package.py
@@ -13,20 +13,32 @@ class Sp(CMakePackage):
 
     homepage = "https://noaa-emc.github.io/NCEPLIBS-sp"
     url = "https://github.com/NOAA-EMC/NCEPLIBS-sp/archive/refs/tags/v2.3.3.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-sp"
 
     maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
+    version("develop", branch="develop")
     version("2.4.0", sha256="dbb4280e622d2683b68a28f8e3837744adf9bbbb1e7940856e8f4597f481c708")
     version("2.3.3", sha256="c0d465209e599de3c0193e65671e290e9f422f659f1da928505489a3edeab99f")
 
-    variant("openmp", default=True, description="builds with OpenMP support")
     variant("shared", default=False, description="Build shared library", when="@2.4:")
-    variant("pic", default=True, description="Build with position-independent-code")
+    variant("openmp", default=False, description="Use OpenMP threading")
+    variant("pic", default=False, description="Enable position-independent code (PIC)")
+    variant(
+        "precision",
+        default=["4", "d"],
+        values=["4", "d", "8"],
+        multi=True,
+        description="Library versions: 4=4-byte reals, d=8-byte reals, 8=8-byte ints and reals",
+        when="@2.4:",
+    )
 
     def setup_run_environment(self, env):
-        suffixes = ["4", "d"]
-        if self.spec.satisfies("@:2.3"):
-            suffixes += ["8"]
+        if self.spec.satisfies("@2.4:"):
+            suffixes = self.spec.variants["precision"].value
+        else:
+            suffixes = ["4", "d", "8"]
+
         for suffix in suffixes:
             lib = find_libraries(
                 "libsp_" + suffix,
@@ -38,9 +50,11 @@ class Sp(CMakePackage):
             env.set("SP_INC" + suffix, "include_" + suffix)
 
     def cmake_args(self):
-        args = [
-            self.define_from_variant("OPENMP", "openmp"),
-            self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
-            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
-        ]
+        args = []
+        args.append(self.define_from_variant("BUILD_SHARED_LIBS", "shared"))
+        args.append(self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"))
+        args.append(self.define_from_variant("OPENMP", "openmp"))
+        args.append(self.define("BUILD_4", self.spec.satisfies("precision=4")))
+        args.append(self.define("BUILD_D", self.spec.satisfies("precision=d")))
+        args.append(self.define("BUILD_8", self.spec.satisfies("precision=8")))
         return args


### PR DESCRIPTION
This PR adds a Spack-based CI workflow. It adds a repo subdirectory called spack/, which contains a package.py which is then used to build sp in the CI. The CI checks every combination of variants.

Fixes https://github.com/NOAA-EMC/NCEPLIBS-sp/issues/116