### PR TITLE
Ensure ctest runs in spack (CI)

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -17,15 +17,16 @@ on:
 
 jobs:
   # This job builds with Spack using every combination of variants and runs the CTest suite each time
-  Linux:
-    runs-on: ubuntu-latest
+  Spack:
 
     strategy:
       matrix:
+        os: ["ubuntu-latest"]
         openmp: ["+openmp", "~openmp"]
         sharedlibs: ["+shared", "~shared"]
         pic: ["+pic", "~pic"]
         precision: ["precision=d", "precision=4", "precision=8"]
+    runs-on: ${{ matrix.os }}
 
     steps:
     
@@ -46,7 +47,10 @@ jobs:
         spack add sp@develop%gcc@11 ${{ matrix.openmp }} ${{ matrix.sharedlibs }} ${{ matrix.pic }} ${{ matrix.precision }}
         spack external find cmake gmake
         spack concretize
-        spack install --verbose --test root
+        # Run installation and run CTest suite
+        spack install --verbose --fail-fast --test root
+        # Run 'spack load' to check for obvious errors in setup_run_environment
+        spack load sp
 
   # This job validates the Spack recipe by making sure each cmake build option is represented
   recipe-check:

--- a/spack/package.py
+++ b/spack/package.py
@@ -15,7 +15,7 @@ class Sp(CMakePackage):
     url = "https://github.com/NOAA-EMC/NCEPLIBS-sp/archive/refs/tags/v2.3.3.tar.gz"
     git = "https://github.com/NOAA-EMC/NCEPLIBS-sp"
 
-    maintainers("t-brown", "AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
+    maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA")
 
     version("develop", branch="develop")
     version("2.4.0", sha256="dbb4280e622d2683b68a28f8e3837744adf9bbbb1e7940856e8f4597f481c708")
@@ -59,7 +59,7 @@ class Sp(CMakePackage):
         args.append(self.define("BUILD_8", self.spec.satisfies("precision=8")))
         args.append(self.define("BUILD_DEPRECATED", False))
         if self.spec.satisfies("@2.4:"):
-            args.append(self.define("BUILD_TESTING"), self.run_tests)
+            args.append(self.define("BUILD_TESTING", self.run_tests))
         return args
 
     def check(self):

--- a/spack/package.py
+++ b/spack/package.py
@@ -26,8 +26,8 @@ class Sp(CMakePackage):
     variant("pic", default=False, description="Enable position-independent code (PIC)")
     variant(
         "precision",
-        default=["4", "d"],
-        values=["4", "d", "8"],
+        default=("4", "d"),
+        values=("4", "d", "8"),
         multi=True,
         description="Library versions: 4=4-byte reals, d=8-byte reals, 8=8-byte ints and reals",
         when="@2.4:",
@@ -37,7 +37,7 @@ class Sp(CMakePackage):
         if self.spec.satisfies("@2.4:"):
             suffixes = self.spec.variants["precision"].value
         else:
-            suffixes = ["4", "d", "8"]
+            suffixes = ("4", "d", "8")
 
         for suffix in suffixes:
             lib = find_libraries(

--- a/spack/package.py
+++ b/spack/package.py
@@ -58,4 +58,10 @@ class Sp(CMakePackage):
         args.append(self.define("BUILD_D", self.spec.satisfies("precision=d")))
         args.append(self.define("BUILD_8", self.spec.satisfies("precision=8")))
         args.append(self.define("BUILD_DEPRECATED", False))
+        if self.spec.satisfies("@2.4:"):
+            args.append(self.define("BUILD_TESTING"), self.run_tests)
         return args
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
As with ip and others, I'm adding some updates here to ensure that Spack CI runs cannot silently fail if the make test target isn't found.

Addresses #116 (addendum to #117)